### PR TITLE
Make docker runnable again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine
 COPY sockd.sh /usr/local/bin/
 
 RUN true \
-    && echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+    && echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && apk add --update-cache dante-server openvpn bash openresolv openrc \
     && rm -rf /var/cache/apk/* \
     && chmod a+x /usr/local/bin/sockd.sh \

--- a/sockd.conf
+++ b/sockd.conf
@@ -1,6 +1,6 @@
 logoutput: stderr
 
-internal: eth0 port = 1080
+internal: 0.0.0.0 port = 1080
 external: tun0
 
 user.unprivileged: sockd


### PR DESCRIPTION
dante-server is part of edge/community now.

on my system it also couldn't bind on eth0 (known issue seen elsewhere) so I had it bind on 0.0.0.0.
